### PR TITLE
Potential fix for code scanning alert no. 18: Incomplete URL substring sanitization

### DIFF
--- a/extension/src/ui/hoverRenderer.ts
+++ b/extension/src/ui/hoverRenderer.ts
@@ -948,7 +948,7 @@ export class HoverRenderer {
             if (!host) {
                 return null;
             }
-            return host.includes('docs.python.org') ? 'Python docs' : host;
+            return host === 'docs.python.org' ? 'Python docs' : host;
         } catch {
             return null;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/KiidxAtlas/python-hover/security/code-scanning/18](https://github.com/KiidxAtlas/python-hover/security/code-scanning/18)

In general, to fix this class of problems you should avoid substring checks on entire URLs or hostnames and instead perform explicit, structured comparisons: parse the URL, extract the hostname, normalize it (e.g., strip `www.`), and then either compare it against an explicit allowlist or check that it matches exactly or as a proper domain suffix (e.g., `host === 'python.org'` or `host.endsWith('.python.org')`).

For this specific code, we should replace `host.includes('docs.python.org')` with a strict check that the hostname is exactly `docs.python.org` or potentially a defined set of equivalent hosts. Since this code only generates a label, we don’t need a complex allowlist; a simple exact equality is sufficient and preserves existing behavior for the main site. If, in future, other official doc hosts (like `docs.python.org.cn`) should be treated as “Python docs,” these can be added explicitly.

Concretely, in `extension/src/ui/hoverRenderer.ts` inside `getDocHostLabel`, change line 951 from:

```ts
return host.includes('docs.python.org') ? 'Python docs' : host;
```

to something like:

```ts
const pythonDocsHosts = new Set(['docs.python.org']);
return pythonDocsHosts.has(host) ? 'Python docs' : host;
```

or, if we want to avoid adding a Set just for this, a simple equality check:

```ts
return host === 'docs.python.org' ? 'Python docs' : host;
```

No additional imports are needed because we are not introducing external libraries, and the rest of the method remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
