### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete URL substring sanitization

### DIFF
--- a/docs-engine/src/docResolver.ts
+++ b/docs-engine/src/docResolver.ts
@@ -134,7 +134,17 @@ export class DocResolver {
     private getCorpusGroupForIndexedSymbol(symbol: IndexedSymbolSummary): string | undefined {
         const root = symbol.package || symbol.name.split('.')[0] || '';
         const baseUrl = this.inventoryFetcher.getPackageBaseUrl(root) || this.inventoryFetcher.getPackageBaseUrl('builtins');
-        return baseUrl?.includes('docs.python.org') ? PYHOVER_PYTHON_STDLIB_CORPUS_GROUP : undefined;
+        if (!baseUrl) {
+            return undefined;
+        }
+
+        try {
+            const parsed = new URL(baseUrl);
+            return parsed.hostname === 'docs.python.org' ? PYHOVER_PYTHON_STDLIB_CORPUS_GROUP : undefined;
+        } catch {
+            // If baseUrl is not a valid URL, fall back to no special corpus group.
+            return undefined;
+        }
     }
 
     async buildPythonStdlibCorpus(


### PR DESCRIPTION
Potential fix for [https://github.com/KiidxAtlas/python-hover/security/code-scanning/16](https://github.com/KiidxAtlas/python-hover/security/code-scanning/16)

In general, the problem should be fixed by parsing the URL and examining its `host` or `hostname` component instead of doing a plain substring match on the full URL string. The host comparison should be explicit, ideally against an allowlist, and allow for exact host matches (and, if desired, specific known subdomains) instead of any occurrence of the string anywhere in the URL.

For this specific case, we should replace `baseUrl?.includes('docs.python.org')` with a check that parses `baseUrl` using Node’s standard `URL` class and inspects the hostname. Since the code appears to want to detect the official Python documentation, we should treat URLs whose hostname is exactly `docs.python.org` or a known subdomain like `docs.python.org` (and possibly `docs.python.org.` but that’s unusual). To avoid changing surrounding behavior, we only adjust the condition: compute a boolean `isPythonStdlibDocs` by attempting to construct a `URL` from `baseUrl`. If parsing fails, or `baseUrl` is falsy, we return `undefined` (current behavior). If parsing succeeds, we check `url.hostname === 'docs.python.org'`. This yields the same true results for properly formed official-docs URLs and avoids accidental matches where `docs.python.org` is in some other part of the URL string.

Concretely, in `docs-engine/src/docResolver.ts`, inside `getCorpusGroupForIndexedSymbol`, replace the line using `.includes('docs.python.org')` with a small parsed-URL based check. We can safely use the global `URL` constructor available in modern Node without adding imports. No other functions or files need changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
