### PR TITLE
Potential fix for code scanning alert no. 14: Incomplete multi-character sanitization

### DIFF
--- a/docs-engine/src/scraping/sphinxScraper.ts
+++ b/docs-engine/src/scraping/sphinxScraper.ts
@@ -1008,6 +1008,15 @@ export class SphinxScraper {
         md = md.replace(/[ \t]+\n/g, '\n');
         md = md.replace(/\n{3,}/g, '\n\n');
 
+        // As a final safety step, strip any script tags that might have been
+        // reintroduced by HTML entity decoding above.
+        let prev: string;
+        const scriptTagPattern = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+        do {
+            prev = md;
+            md = md.replace(scriptTagPattern, '');
+        } while (md !== prev);
+
         return md.trim();
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/KiidxAtlas/python-hover/security/code-scanning/14](https://github.com/KiidxAtlas/python-hover/security/code-scanning/14)

In general, the problem is that the sanitization first removes tags with a regex, then decodes HTML entities, which can recreate `<` and `>` characters and thus resurrect tags such as `<script>`. To fix this without changing existing functionality too much, we should ensure that after all entity decoding and whitespace normalization, the resulting string no longer contains dangerous HTML constructs, especially script blocks. Two straightforward strategies, both compatible with the existing pipeline, are: (1) escape any `<` characters that could start an HTML tag, or (2) remove or neutralize `<script>` tags specifically after decoding. Since this output is intended as Markdown, preserving `<` and `>` as plain text is often desirable (for code samples etc.), so the best minimal fix is to strip any `<script ...>...</script>` blocks that might have been reintroduced by entity decoding.

Concretely, we should add a final sanitization step after the existing entity decoding and whitespace normalization, just before `return md.trim();`. This step will repeatedly remove any `<script>` blocks using a robust regex that handles multiline content and nested `<`/`>` inside the body. To avoid the incomplete multi-character sanitization problem, we will apply the replacement in a loop until no changes occur. All changes will be restricted to `docs-engine/src/scraping/sphinxScraper.ts` inside the shown snippet, and no new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
